### PR TITLE
Prepare 2.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.0.2
+- Updated `repository` and other meta-data in `pubspec.yaml`.
+
 ## v2.0.1
 - License changed to BSD, as this package is now maintained by the Dart team.
 - Fixed minor lints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## v2.0.2
+- Fix trailing whitespace after adding new key with block-value to map
+  ([#15](https://github.com/dart-lang/yaml_edit/issues/15)).
 - Updated `repository` and other meta-data in `pubspec.yaml`.
 
 ## v2.0.1


### PR DESCRIPTION
Follow-up from https://github.com/dart-lang/yaml_edit/pull/6, we should probably publish this :D