### PR TITLE
Fix example usage in README and dartdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ import 'package:yaml_edit/yaml_edit.dart';
 
 void main() {
   final yamlEditor = YamlEditor('{YAML: YAML}');
-  yamlEditor.assign(['YAML'], "YAML Ain't Markup Language");
+  yamlEditor.update(['YAML'], "YAML Ain't Markup Language");
   print(yamlEditor);
   // Expected output:
   // {YAML: YAML Ain't Markup Language}

--- a/lib/yaml_edit.dart
+++ b/lib/yaml_edit.dart
@@ -11,11 +11,11 @@
 /// import 'package:yaml_edit/yaml_edit.dart';
 ///
 /// void main() {
-///  final yamlEditor = YamlEditor('{YAML: YAML}');
-///  yamlEditor.update(['YAML'], "YAML Ain't Markup Language");
-///  print(yamlEditor);
-///  // Expected Output:
-///  // {YAML: YAML Ain't Markup Language}
+///   final yamlEditor = YamlEditor('{YAML: YAML}');
+///   yamlEditor.update(['YAML'], "YAML Ain't Markup Language");
+///   print(yamlEditor);
+///   // Expected Output:
+///   // {YAML: YAML Ain't Markup Language}
 /// }
 /// ```
 ///


### PR DESCRIPTION
This fixes #11 and an indentation issue in the dartdoc.