### PR TITLE
Fix errors caused by newline and whitespace in folded string

### DIFF
--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -108,9 +108,9 @@ String _tryYamlEncodeFolded(String string, int indentation, String lineEnding) {
   /// If the line starts with a empty character (excluding indentation), the
   /// newline character(\n) before and after the line will be remained.
   var emptyBegin = false;
-  var replacedString =
+  final replacedString =
       trimmedString.replaceAllMapped(RegExp(r'\n(.*)'), (match) {
-    var nextLine = match.group(1)!;
+    final nextLine = match.group(1)!;
 
     if (nextLine.startsWith(' ') || nextLine.isEmpty) {
       emptyBegin = true;

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -105,12 +105,31 @@ String _tryYamlEncodeFolded(String string, int indentation, String lineEnding) {
     result = '>-\n' + ' ' * indentation;
   }
 
+  /// If the line starts with a empty character (excluding indentation), the
+  /// newline character(\n) before and after the line will be remained.
+  var emptyBegin = false;
+  var replacedString =
+      trimmedString.replaceAllMapped(RegExp(r'\n(.*)'), (match) {
+    var nextLine = match.group(1)!;
+
+    if (nextLine.startsWith(' ') || nextLine.isEmpty) {
+      emptyBegin = true;
+      return lineEnding + ' ' * indentation + nextLine;
+    }
+
+    if (emptyBegin) {
+      emptyBegin = false;
+      return lineEnding + ' ' * indentation + nextLine;
+    } else {
+      emptyBegin = false;
+      return lineEnding * 2 + ' ' * indentation + nextLine;
+    }
+  });
+
   /// Duplicating the newline for folded strings preserves it in YAML.
   /// Assumes the user did not try to account for windows documents by using
   /// `\r\n` already
-  return result +
-      trimmedString.replaceAll('\n', lineEnding * 2 + ' ' * indentation) +
-      removedPortion;
+  return result + replacedString + removedPortion;
 }
 
 /// Generates a YAML-safe literal string.

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -94,14 +94,6 @@ String _tryYamlEncodeSingleQuoted(String string) {
 /// characters by calling [_hasUnprintableCharacters] before invoking this
 /// function.
 String _tryYamlEncodeFolded(String string, int indentation, String lineEnding) {
-  /// If string starts with whitespaces, we'll fallback to a double quoted string.
-  final leftTrimmedString = string.trimLeft();
-  final leftRemovedPortion =
-      string.substring(0, string.length - leftTrimmedString.length);
-  if (string.isEmpty || leftRemovedPortion.contains(' ')) {
-    return _yamlEncodeDoubleQuoted(string);
-  }
-
   String result;
 
   final rightTrimmedString = string.trimRight();
@@ -149,14 +141,6 @@ String _tryYamlEncodeFolded(String string, int indentation, String lineEnding) {
 /// function.
 String _tryYamlEncodeLiteral(
     String string, int indentation, String lineEnding) {
-  /// If string starts with whitespaces, we'll fallback to a double quoted string.
-  final leftTrimmedString = string.trimLeft();
-  final leftRemovedPortion =
-      string.substring(0, string.length - leftTrimmedString.length);
-  if (string.isEmpty || leftRemovedPortion.contains(' ')) {
-    return _yamlEncodeDoubleQuoted(string);
-  }
-
   String result;
 
   final rightTrimmedString = string.trimRight();

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -9,6 +9,8 @@ import 'package:yaml_edit/yaml_edit.dart';
 final _testStrings = [
   "this is a fairly' long string with\nline breaks",
   "whitespace\n after line breaks",
+  " start with whitespace"
+  "end with line breaks\n"
   "word",
   "foo bar",
   "foo\nbar",
@@ -21,7 +23,7 @@ final _testStrings = [
 final _scalarStyles = [
   ScalarStyle.ANY,
   ScalarStyle.DOUBLE_QUOTED,
-  //ScalarStyle.FOLDED, // TODO: Fix this test case!
+  ScalarStyle.FOLDED,
   ScalarStyle.LITERAL,
   ScalarStyle.PLAIN,
   ScalarStyle.SINGLE_QUOTED,

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -9,8 +9,8 @@ import 'package:yaml_edit/yaml_edit.dart';
 final _testStrings = [
   "this is a fairly' long string with\nline breaks",
   "whitespace\n after line breaks",
-  " start with whitespace"
-  "end with line breaks\n"
+  " start with whitespace",
+  "end with line breaks\n",
   "word",
   "foo bar",
   "foo\nbar",

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -412,6 +412,48 @@ a:
           ]
         });
       });
+
+      group('works with newline whitespace in folded string', () {
+        test('with whitespace newline whitespace', () {
+          final doc = YamlEditor('hello');
+          final node = wrapAsYamlNode(
+            'hello \n world',
+            scalarStyle: ScalarStyle.FOLDED,
+          );
+          doc.update([], node);
+          expect(doc.toString(), equals('>-\n  hello \n   world'));
+        });
+
+        test('with whitespace newline newline whitespace', () {
+          final doc = YamlEditor('hello');
+          final node = wrapAsYamlNode(
+            'hello \n\n world',
+            scalarStyle: ScalarStyle.FOLDED,
+          );
+          doc.update([], node);
+          expect(doc.toString(), equals('>-\n  hello \n  \n   world'));
+        });
+
+        test('with whitespace newline whitespace newline whitespace', () {
+          final doc = YamlEditor('hello');
+          final node = wrapAsYamlNode(
+            'hello \n \n world',
+            scalarStyle: ScalarStyle.FOLDED,
+          );
+          doc.update([], node);
+          expect(doc.toString(), equals('>-\n  hello \n   \n   world'));
+        });
+
+        test('with whitespace newline string newline whitespace', () {
+          final doc = YamlEditor('hello');
+          final node = wrapAsYamlNode(
+            'hello \nstring\n world',
+            scalarStyle: ScalarStyle.FOLDED,
+          );
+          doc.update([], node);
+          expect(doc.toString(), equals('>-\n  hello \n\n  string\n   world'));
+        });
+      });
     });
   });
 

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -412,48 +412,6 @@ a:
           ]
         });
       });
-
-      group('works with newline whitespace in folded string', () {
-        test('with whitespace newline whitespace', () {
-          final doc = YamlEditor('hello');
-          final node = wrapAsYamlNode(
-            'hello \n world',
-            scalarStyle: ScalarStyle.FOLDED,
-          );
-          doc.update([], node);
-          expect(doc.toString(), equals('>-\n  hello \n   world'));
-        });
-
-        test('with whitespace newline newline whitespace', () {
-          final doc = YamlEditor('hello');
-          final node = wrapAsYamlNode(
-            'hello \n\n world',
-            scalarStyle: ScalarStyle.FOLDED,
-          );
-          doc.update([], node);
-          expect(doc.toString(), equals('>-\n  hello \n  \n   world'));
-        });
-
-        test('with whitespace newline whitespace newline whitespace', () {
-          final doc = YamlEditor('hello');
-          final node = wrapAsYamlNode(
-            'hello \n \n world',
-            scalarStyle: ScalarStyle.FOLDED,
-          );
-          doc.update([], node);
-          expect(doc.toString(), equals('>-\n  hello \n   \n   world'));
-        });
-
-        test('with whitespace newline string newline whitespace', () {
-          final doc = YamlEditor('hello');
-          final node = wrapAsYamlNode(
-            'hello \nstring\n world',
-            scalarStyle: ScalarStyle.FOLDED,
-          );
-          doc.update([], node);
-          expect(doc.toString(), equals('>-\n  hello \n\n  string\n   world'));
-        });
-      });
     });
   });
 


### PR DESCRIPTION
fixes: #41

## Test data:
input: `hello \n world`
output:
```yaml
>-
  hello 
   world
```

input: `hello \n\n world`
output:
```yaml
>-
  hello 
  
   world
```

input: `hello \n \n world`
output:
```yaml
>-
  hello 
   
   world
```

input: `hello \nstring\n world`
output:
```yaml
>-
  hello 

  string
   world
```
