### PR TITLE
updates for the next version of package:yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.1.1
+
+- Update to work with an unreleased version of `package:yaml`.
+
 ## v2.1.0
 - **Breaking** `wrapAsYamlNode(value, collectionStyle, scalarStyle)` will apply
   `collectionStyle` and `scalarStyle` recursively when wrapping a children of

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -139,13 +139,14 @@ String _yamlEncodeFlowScalar(YamlNode value) {
     assertValidScalar(value.value);
 
     if (value.value is String) {
-      if (_hasUnprintableCharacters(value.value) ||
+      final val = value.value as String;
+      if (_hasUnprintableCharacters(val) ||
           value.style == ScalarStyle.DOUBLE_QUOTED) {
-        return _yamlEncodeDoubleQuoted(value.value);
+        return _yamlEncodeDoubleQuoted(val);
       }
 
       if (value.style == ScalarStyle.SINGLE_QUOTED) {
-        return _tryYamlEncodeSingleQuoted(value.value);
+        return _tryYamlEncodeSingleQuoted(val);
       }
     }
 
@@ -172,23 +173,23 @@ String yamlEncodeBlockScalar(
     assertValidScalar(value.value);
 
     if (value.value is String) {
-      if (_hasUnprintableCharacters(value.value)) {
-        return _yamlEncodeDoubleQuoted(value.value);
+      final val = value.value as String;
+      if (_hasUnprintableCharacters(val)) {
+        return _yamlEncodeDoubleQuoted(val);
       }
 
       if (value.style == ScalarStyle.SINGLE_QUOTED) {
-        return _tryYamlEncodeSingleQuoted(value.value);
+        return _tryYamlEncodeSingleQuoted(val);
       }
 
       // Strings with only white spaces will cause a misparsing
-      if (value.value.trim().length == value.value.length &&
-          value.value.length != 0) {
+      if (val.trim().length == val.length && val.isNotEmpty) {
         if (value.style == ScalarStyle.FOLDED) {
-          return _tryYamlEncodeFolded(value.value, indentation, lineEnding);
+          return _tryYamlEncodeFolded(val, indentation, lineEnding);
         }
 
         if (value.style == ScalarStyle.LITERAL) {
-          return _tryYamlEncodeLiteral(value.value, indentation, lineEnding);
+          return _tryYamlEncodeLiteral(val, indentation, lineEnding);
         }
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yaml_edit
-version: 2.1.0
+version: 2.1.1
 description: A library for YAML manipulation with comment and whitespace preservation.
 repository: https://github.com/dart-lang/yaml_edit
 issue_tracker: https://github.com/dart-lang/yaml_edit/issues


### PR DESCRIPTION
- updates for the next version of package:yaml

A newer (unreleased) version of package:yaml adds a bit more type info to it's API; this change lets yaml_edit work with either the current (dynamic) version of the API, or the new (`Object?`) version of the API.

https://github.com/dart-lang/yaml/commit/1ad2f49ecbea03460b87ea28709f5ed0213077b0#r103444673

cc @kevmoo @jonasfj 