### PR TITLE
Fix line endings for inserted maps on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+- Fix inconsistent line endings when inserting maps into a document using `\r\n`.
+  ([#65](https://github.com/dart-lang/yaml_edit/issues/65))
+
 ## 2.2.0
 - `AliasError` is changed to `AliasException` and exposed in the public API.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 2.2.1
+## 2.2.0
+
 - Fix inconsistent line endings when inserting maps into a document using `\r\n`.
   ([#65](https://github.com/dart-lang/yaml_edit/issues/65))
 
-## 2.2.0
 - `AliasError` is changed to `AliasException` and exposed in the public API.
 
   All node-mutating methods on `YamlEditor`, i.e. `update()`, `appendToList()`,
@@ -17,6 +17,7 @@
 - Require Dart 2.19
 
 ## 2.1.0
+
 - **Breaking** `wrapAsYamlNode(value, collectionStyle, scalarStyle)` will apply
   `collectionStyle` and `scalarStyle` recursively when wrapping a children of
   `Map` and `List`.
@@ -30,18 +31,22 @@
   ([#23](https://github.com/dart-lang/yaml_edit/issues/23))
 
 ## 2.0.3
+
 - Updated the value of the pubspec `repository` field.
 
 ## 2.0.2
+
 - Fix trailing whitespace after adding new key with block-value to map
   ([#15](https://github.com/dart-lang/yaml_edit/issues/15)).
 - Updated `repository` and other meta-data in `pubspec.yaml`.
 
 ## 2.0.1
+
 - License changed to BSD, as this package is now maintained by the Dart team.
 - Fixed minor lints.
 
 ## 2.0.0
+
 - Migrated to null-safety.
 - API will no-longer return `null` in-place of a `YamlNode`, instead a
   `YamlNode` with `YamlNode.value == null` should be used. These are easily

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -274,7 +274,7 @@ String yamlEncodeBlockString(
       /// Empty collections are always encoded in flow-style, so new-line must
       /// be avoided
       if (isCollection(entry.value) && !isEmpty(entry.value)) {
-        return '$formattedKey:\n$formattedValue';
+        return '$formattedKey:$lineEnding$formattedValue';
       }
 
       return '$formattedKey: $formattedValue';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yaml_edit
-version: 2.2.1
+version: 2.2.0
 description: A library for YAML manipulation with comment and whitespace preservation.
 repository: https://github.com/dart-lang/yaml_edit
 issue_tracker: https://github.com/dart-lang/yaml_edit/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yaml_edit
-version: 2.2.0
+version: 2.2.1
 description: A library for YAML manipulation with comment and whitespace preservation.
 repository: https://github.com/dart-lang/yaml_edit
 issue_tracker: https://github.com/dart-lang/yaml_edit/issues

--- a/test/windows_test.dart
+++ b/test/windows_test.dart
@@ -167,6 +167,25 @@ c: 3\r
       expectYamlBuilderValue(doc, []);
     });
 
+    test('inserted nested map', () {
+      final doc = YamlEditor('''
+a:\r
+  b:\r
+''');
+      doc.update(
+        ['a', 'b'],
+        {
+          'c': {'d': 'e'}
+        },
+      );
+      expect(doc.toString(), equals('''
+a:\r
+  b:\r
+    c:\r
+      d: e\r
+'''));
+    });
+
     test('remove from block map', () {
       final doc = YamlEditor('''
 a: 1\r


### PR DESCRIPTION
Replaces a hard-coded `\n` to instead use the correct line-ending for the document.

This fixes an issue where documents on Windows using `\r\n` could end up with mismatched newlines.

@kevmoo I bumped the version and added to changelog, but not sure what the process is (and there's no contributing file here).

Fixes https://github.com/dart-lang/yaml_edit/issues/65