### PR TITLE
Fix 55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 2.2.1-wip
+## 2.2.1
 
 - Require Dart 3.0
+- Fix removal of last key in blockmap when key has no value
+  ([#55](https://github.com/dart-lang/yaml_edit/issues/55)).
 
 ## 2.2.0
 

--- a/lib/src/map_mutations.dart
+++ b/lib/src/map_mutations.dart
@@ -145,6 +145,7 @@ SourceEdit _replaceInBlockMap(
   }
 
   /// +1 accounts for the colon
+  // TODO: What if here is a whitespace following the key, before the colon?
   final start = keyNode.span.end.offset + 1;
   var end = getContentSensitiveEnd(map.nodes[key]!);
 
@@ -175,9 +176,18 @@ SourceEdit _removeFromBlockMap(
   final keySpan = keyNode.span;
   var end = getContentSensitiveEnd(valueNode);
   final yaml = yamlEdit.toString();
+  final lineEnding = getLineEnding(yaml);
 
   if (map.length == 1) {
     final start = map.span.start.offset;
+    final nextNewLine = yaml.indexOf(lineEnding, end);
+    if (nextNewLine != -1) {
+      // Remove everything up to the next newline, this strips comments that
+      // follows on the same line as the value we're removing.
+      // It also fixes bugs when empty string represents `null`, and [end] with
+      // then otherwise point to the colon.
+      end = nextNewLine;
+    }
     return SourceEdit(start, end - start, '{}');
   }
 
@@ -187,16 +197,16 @@ SourceEdit _removeFromBlockMap(
   ///
   /// We do this because we suspect that our users will want the inline
   /// comments to disappear too.
-  final nextNewLine = yaml.indexOf('\n', end);
+  final nextNewLine = yaml.indexOf(lineEnding, end);
   if (nextNewLine != -1) {
-    end = nextNewLine + 1;
+    end = nextNewLine + lineEnding.length;
   }
 
   final nextNode = getNextKeyNode(map, keyNode);
 
   if (start > 0) {
     final lastHyphen = yaml.lastIndexOf('-', start - 1);
-    final lastNewLine = yaml.lastIndexOf('\n', start - 1);
+    final lastNewLine = yaml.lastIndexOf(lineEnding, start - 1);
     if (lastHyphen > lastNewLine) {
       start = lastHyphen + 2;
 
@@ -208,7 +218,7 @@ SourceEdit _removeFromBlockMap(
         end += nextNode.span.start.column;
       }
     } else if (lastNewLine > lastHyphen) {
-      start = lastNewLine + 1;
+      start = lastNewLine + lineEnding.length;
     }
   }
 

--- a/lib/src/map_mutations.dart
+++ b/lib/src/map_mutations.dart
@@ -184,8 +184,9 @@ SourceEdit _removeFromBlockMap(
     if (nextNewLine != -1) {
       // Remove everything up to the next newline, this strips comments that
       // follows on the same line as the value we're removing.
-      // It also fixes bugs when empty string represents `null`, and [end] with
-      // then otherwise point to the colon.
+      // It also ensures we consume colon when [valueNode.value] is `null`
+      // because there is no value (e.g. `key: \n`). Because [valueNode.span] in
+      // such cases point to the colon `:`.
       end = nextNewLine;
     }
     return SourceEdit(start, end - start, '{}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: yaml_edit
-version: 2.2.1-wip
+version: 2.2.1
 description: >-
   A library for YAML manipulation with comment and whitespace preservation.
 repository: https://github.com/dart-lang/yaml_edit

--- a/test/testdata/input/issue_55.test
+++ b/test/testdata/input/issue_55.test
@@ -1,0 +1,11 @@
+TEST FOR ISSUE #55 -- https://github.com/dart-lang/yaml_edit/issues/55
+---
+name: sample
+version: 0.1.0
+environment:
+  sdk: ^3.0.0
+dependencies:
+dev_dependencies:
+  retry:
+---
+ - [remove, ['dev_dependencies', 'retry']]

--- a/test/testdata/input/remove_key.test
+++ b/test/testdata/input/remove_key.test
@@ -1,0 +1,6 @@
+REMOVE KEY FROM MAP
+---
+foo: true
+bar: false
+---
+- [remove, [bar]]

--- a/test/testdata/input/remove_key_with_trailing_comma.test
+++ b/test/testdata/input/remove_key_with_trailing_comma.test
@@ -1,0 +1,6 @@
+REMOVE KEY FROM MAP WITH TRAILING COMMA
+---
+foo: true
+bar: false # remove this comment
+---
+- [remove, [bar]]

--- a/test/testdata/input/remove_nested_key.test
+++ b/test/testdata/input/remove_nested_key.test
@@ -1,0 +1,9 @@
+REMOVE NESTED KEY FROM MAP
+---
+A: true
+B:
+  foo: true
+  bar: true
+---
+- [remove, [B, foo]]
+- [remove, [B, bar]]

--- a/test/testdata/input/remove_nested_key_with_null.test
+++ b/test/testdata/input/remove_nested_key_with_null.test
@@ -1,0 +1,7 @@
+REMOVE NESTED KEY FROM MAP WITH NULL
+---
+A: true
+B:
+  foo:
+---
+- [remove, [B, foo]]

--- a/test/testdata/input/remove_nested_key_with_trailing_comma.test
+++ b/test/testdata/input/remove_nested_key_with_trailing_comma.test
@@ -1,0 +1,7 @@
+REMOVE NESTED KEY FROM MAP WITH TRAILING COMMA
+---
+A: true
+B:
+  bar: false # remove this comment
+---
+- [remove, [B, bar]]

--- a/test/testdata/output/issue_55.golden
+++ b/test/testdata/output/issue_55.golden
@@ -1,0 +1,15 @@
+name: sample
+version: 0.1.0
+environment:
+  sdk: ^3.0.0
+dependencies:
+dev_dependencies:
+  retry:
+---
+name: sample
+version: 0.1.0
+environment:
+  sdk: ^3.0.0
+dependencies:
+dev_dependencies:
+  {}

--- a/test/testdata/output/remove_key.golden
+++ b/test/testdata/output/remove_key.golden
@@ -1,0 +1,4 @@
+foo: true
+bar: false
+---
+foo: true

--- a/test/testdata/output/remove_key_with_trailing_comma.golden
+++ b/test/testdata/output/remove_key_with_trailing_comma.golden
@@ -1,0 +1,4 @@
+foo: true
+bar: false # remove this comment
+---
+foo: true

--- a/test/testdata/output/remove_nested_key.golden
+++ b/test/testdata/output/remove_nested_key.golden
@@ -1,0 +1,12 @@
+A: true
+B:
+  foo: true
+  bar: true
+---
+A: true
+B:
+  bar: true
+---
+A: true
+B:
+  {}

--- a/test/testdata/output/remove_nested_key_with_null.golden
+++ b/test/testdata/output/remove_nested_key_with_null.golden
@@ -1,0 +1,7 @@
+A: true
+B:
+  foo:
+---
+A: true
+B:
+  {}

--- a/test/testdata/output/remove_nested_key_with_trailing_comma.golden
+++ b/test/testdata/output/remove_nested_key_with_trailing_comma.golden
@@ -1,0 +1,7 @@
+A: true
+B:
+  bar: false # remove this comment
+---
+A: true
+B:
+  {}


### PR DESCRIPTION
**please double check golden files during review**

--------------

Fixes https://github.com/dart-lang/yaml_edit/issues/55.

When the value is empty the `SourceSpan` for the `YamlNode` representing
the value in a map points to the colon.

Example:
```yaml
foo:
  bar:
```

The `YamlNode` for `foo.bar` has a value of `null` and starts and ends
at the colon `:` following `bar`. This means that removal might leave
the colon behind, which causes invalid YAML.

We have the same issue when removing `foo.bar` from the following YAML
document:

```yaml
foo:
  baz: true
  bar:
```

However, in this case, we have a hack that ensures we always strip away
the any comments that follows `bar`. We do this by deleting up-to the
next newline. If we apply the same hack when removing `foo.bar` in the
first example, then it works.

One could argue that it works by accident, but it's kind of desired that
trailing comments are removed, when the value they are trailing is
removed.