### PR TITLE
Consume until end of document if there is no newline when removing from

### DIFF
--- a/lib/src/map_mutations.dart
+++ b/lib/src/map_mutations.dart
@@ -188,6 +188,9 @@ SourceEdit _removeFromBlockMap(
       // because there is no value (e.g. `key: \n`). Because [valueNode.span] in
       // such cases point to the colon `:`.
       end = nextNewLine;
+    } else {
+      // Remove everything until the end of the document, if there is no newline
+      end = yaml.length;
     }
     return SourceEdit(start, end - start, '{}');
   }
@@ -201,6 +204,9 @@ SourceEdit _removeFromBlockMap(
   final nextNewLine = yaml.indexOf(lineEnding, end);
   if (nextNewLine != -1) {
     end = nextNewLine + lineEnding.length;
+  } else {
+    // Remove everything until the end of the document, if there is no newline
+    end = yaml.length;
   }
 
   final nextNode = getNextKeyNode(map, keyNode);

--- a/test/remove_test.dart
+++ b/test/remove_test.dart
@@ -217,6 +217,30 @@ b:
 c: 3
 '''));
     });
+
+    test('issue #55 reopend', () {
+      final doc = YamlEditor('''name: sample
+version: 0.1.0
+environment:
+  sdk: ^3.0.0
+dependencies:
+  retry: ^3.1.2
+dev_dependencies:
+  retry:''');
+      doc.remove(['dev_dependencies']);
+    });
+
+    test('issue #55 reopend, variant 2', () {
+      final doc = YamlEditor('''name: sample
+version: 0.1.0
+environment:
+  sdk: ^3.0.0
+dependencies:
+  retry: ^3.1.2
+dev_dependencies:
+  retry:''');
+      doc.remove(['dev_dependencies', 'retry']);
+    });
   });
 
   group('flow map', () {


### PR DESCRIPTION
block map.

Fixes #55.

