### PR TITLE
Better logging in random_test.dart, and less overall noise from warnings

### DIFF
--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -574,7 +574,7 @@ class YamlEditor {
           _yaml);
     }
 
-    final actualTree = loadYamlNode(_yaml);
+    final actualTree = withYamlWarningCallback(() => loadYamlNode(_yaml));
     if (!deepEquals(actualTree, expectedTree)) {
       throw createAssertionError(
           'Modification did not result in expected result.',

--- a/test/random_test.dart
+++ b/test/random_test.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-import 'dart:math';
+import 'dart:math' show Random;
 
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
@@ -44,15 +43,10 @@ dev_dependencies:
 ''');
 
       for (var j = 0; j < modificationsPerRound; j++) {
-        /// Using [runZoned] to hide `package:yaml`'s warnings.
-        /// Test failures and errors will still be shown.
-        runZoned(() {
-          expect(
-              () => generator.performNextModification(editor), returnsNormally);
-        },
-            zoneSpecification: ZoneSpecification(
-                print: (Zone self, ZoneDelegate parent, Zone zone,
-                    String message) {}));
+        expect(
+          () => generator.performNextModification(editor),
+          returnsNormally,
+        );
       }
     });
   }


### PR DESCRIPTION
Noticed that we never set [`yamlWarningCallback`](https://pub.dev/documentation/yaml/latest/yaml/yamlWarningCallback.html) when parsing YAML internally, this meant that the terminal would show warnings.

This is sad, because some of the internal stuff really only used `loadYamlNode` to determine if a string needed to be quoted, or if the edits were sane -- so warnings aren't actually intended for the end-user.

One could argue that we should avoid edits that produce warnings, but that seems to an orthogonal concern, this really just stops warnings produces internally from polluting stdout.