### PR TITLE
Fix line ending bug

### DIFF
--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -245,8 +245,15 @@ class YamlEditor {
       final lineEnding = getLineEnding(_yaml);
       end = skipAndExtractCommentsInBlock(_yaml, end, null, lineEnding).$1;
       var encoded = yamlEncodeBlock(valueNode, 0, lineEnding);
-      encoded =
-          normalizeEncodedBlock(_yaml, lineEnding, end, valueNode, encoded);
+      encoded = normalizeEncodedBlock(
+        _yaml,
+        lineEnding: lineEnding,
+        nodeToReplaceEndOffset: end,
+        update: valueNode,
+        updateAsString: encoded,
+        skipPreservationCheck: true,
+        isTopLevelScalar: true,
+      );
       final edit = SourceEdit(start, end - start, encoded);
       return _performEdit(edit, path, valueNode);
     }

--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -252,7 +252,6 @@ class YamlEditor {
         update: valueNode,
         updateAsString: encoded,
         skipPreservationCheck: true,
-        isTopLevelScalar: true,
       );
       final edit = SourceEdit(start, end - start, encoded);
       return _performEdit(edit, path, valueNode);

--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -243,13 +243,14 @@ class YamlEditor {
       final start = _contents.span.start.offset;
       var end = getContentSensitiveEnd(_contents);
       final lineEnding = getLineEnding(_yaml);
+
       end = skipAndExtractCommentsInBlock(
         _yaml,
-        end,
-        null,
+        endOfNodeOffset: end,
         lineEnding: lineEnding,
         greedy: true,
-      ).$1;
+      ).endOffset;
+
       var encoded = yamlEncodeBlock(valueNode, 0, lineEnding);
       encoded = normalizeEncodedBlock(
         _yaml,

--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -243,7 +243,13 @@ class YamlEditor {
       final start = _contents.span.start.offset;
       var end = getContentSensitiveEnd(_contents);
       final lineEnding = getLineEnding(_yaml);
-      end = skipAndExtractCommentsInBlock(_yaml, end, null, lineEnding).$1;
+      end = skipAndExtractCommentsInBlock(
+        _yaml,
+        end,
+        null,
+        lineEnding: lineEnding,
+        greedy: true,
+      ).$1;
       var encoded = yamlEncodeBlock(valueNode, 0, lineEnding);
       encoded = normalizeEncodedBlock(
         _yaml,

--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -243,9 +243,10 @@ class YamlEditor {
       final start = _contents.span.start.offset;
       final end = getContentSensitiveEnd(_contents);
       final lineEnding = getLineEnding(_yaml);
-      final edit = SourceEdit(
-          start, end - start, yamlEncodeBlock(valueNode, 0, lineEnding));
-
+      var encoded = yamlEncodeBlock(valueNode, 0, lineEnding);
+      encoded =
+          normalizeEncodedBlock(_yaml, lineEnding, end, valueNode, encoded);
+      final edit = SourceEdit(start, end - start, encoded);
       return _performEdit(edit, path, valueNode);
     }
 
@@ -483,7 +484,7 @@ class YamlEditor {
         if (!containsKey(map, keyOrIndex)) {
           return _pathErrorOrElse(path, path.take(i + 1), map, orElse);
         }
-        final keyNode = getKeyNode(map, keyOrIndex);
+        final (_, keyNode) = getKeyNode(map, keyOrIndex);
 
         if (checkAlias) {
           if (_aliases.contains(keyNode)) throw AliasException(path, keyNode);

--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -241,8 +241,9 @@ class YamlEditor {
 
     if (path.isEmpty) {
       final start = _contents.span.start.offset;
-      final end = getContentSensitiveEnd(_contents);
+      var end = getContentSensitiveEnd(_contents);
       final lineEnding = getLineEnding(_yaml);
+      end = skipAndExtractCommentsInBlock(_yaml, end, null, lineEnding).$1;
       var encoded = yamlEncodeBlock(valueNode, 0, lineEnding);
       encoded =
           normalizeEncodedBlock(_yaml, lineEnding, end, valueNode, encoded);

--- a/lib/src/equality.dart
+++ b/lib/src/equality.dart
@@ -87,8 +87,10 @@ int deepHashCode(Object? value) {
 }
 
 /// Returns the [YamlNode] corresponding to the provided [key].
-YamlNode getKeyNode(YamlMap map, Object? key) {
-  return map.nodes.keys.firstWhere((node) => deepEquals(node, key)) as YamlNode;
+(int index, YamlNode keyNode) getKeyNode(YamlMap map, Object? key) {
+  return map.nodes.keys.indexed.firstWhere(
+    (value) => deepEquals(value.$2, key),
+  ) as (int, YamlNode);
 }
 
 /// Returns the [YamlNode] after the [YamlNode] corresponding to the provided

--- a/lib/src/list_mutations.dart
+++ b/lib/src/list_mutations.dart
@@ -57,7 +57,7 @@ SourceEdit updateInList(
     final (offsetOfLastComment, _) =
         skipAndExtractCommentsInBlock(yaml, end, null, lineEnding);
     end = offsetOfLastComment;
-    
+
     valueString =
         normalizeEncodedBlock(yaml, lineEnding, end, newValue, valueString);
 

--- a/lib/src/list_mutations.dart
+++ b/lib/src/list_mutations.dart
@@ -58,13 +58,13 @@ SourceEdit updateInList(
         skipAndExtractCommentsInBlock(yaml, end, null, lineEnding);
     end = offsetOfLastComment;
 
-    valueString =
-        normalizeEncodedBlock(yaml, lineEnding, end, newValue, valueString);
-
-    /// [skipAndExtractCommentsInBlock] is greedy and eats up any whitespace
-    /// it encounters in search of comments. Compensate indent lost in the
-    /// current edit
-    if (index != list.length - 1) valueString += ' ' * listIndentation;
+    valueString = normalizeEncodedBlock(
+      yaml,
+      lineEnding: lineEnding,
+      nodeToReplaceEndOffset: end,
+      update: newValue,
+      updateAsString: valueString,
+    );
 
     return SourceEdit(offset, end - offset, valueString);
   } else {

--- a/lib/src/map_mutations.dart
+++ b/lib/src/map_mutations.dart
@@ -131,8 +131,7 @@ SourceEdit _replaceInBlockMap(
   final mapIndentation = getMapIndentation(yaml, map);
   final newIndentation = mapIndentation + getIndentation(yamlEdit);
 
-  // TODO: Compensate for the indent eaten up
-  final (keyIndex, keyNode) = getKeyNode(map, key);
+  final (_, keyNode) = getKeyNode(map, key);
 
   var valueAsString = yamlEncodeBlock(
     wrapAsYamlNode(newValue),
@@ -187,13 +186,13 @@ SourceEdit _replaceInBlockMap(
       skipAndExtractCommentsInBlock(yaml, end, null, lineEnding);
   end = offsetOfLastComment;
 
-  valueAsString =
-      normalizeEncodedBlock(yaml, lineEnding, end, newValue, valueAsString);
-
-  /// [skipAndExtractCommentsInBlock] is greedy and eats up any whitespace
-  /// it encounters in search of comments. Compensate indent lost in the
-  /// current edit
-  if (keyIndex != map.length - 1) valueAsString += ' ' * mapIndentation;
+  valueAsString = normalizeEncodedBlock(
+    yaml,
+    lineEnding: lineEnding,
+    nodeToReplaceEndOffset: end,
+    update: newValue,
+    updateAsString: valueAsString,
+  );
 
   return SourceEdit(start, end - start, valueAsString);
 }

--- a/lib/src/map_mutations.dart
+++ b/lib/src/map_mutations.dart
@@ -227,7 +227,7 @@ SourceEdit _removeFromBlockMap(
   /// Null values have an invalid offset. Include colon.
   ///
   /// See issue open in `package: yaml`.
-  var endOffset = valueNode.value == null
+  var endOffset = valueNode.span.length == 0
       ? keySpan.end.offset + 2
       : getContentSensitiveEnd(valueNode) + 1; // Overeager to avoid issues
 

--- a/lib/src/map_mutations.dart
+++ b/lib/src/map_mutations.dart
@@ -181,10 +181,12 @@ SourceEdit _replaceInBlockMap(
           ? start + 1
           : end;
 
-  // Aggressively skip all comments
-  final (offsetOfLastComment, _) =
-      skipAndExtractCommentsInBlock(yaml, end, null, lineEnding: lineEnding);
-  end = offsetOfLastComment;
+  // Skip comments lazily
+  end = skipAndExtractCommentsInBlock(
+    yaml,
+    endOfNodeOffset: end,
+    lineEnding: lineEnding,
+  ).endOffset;
 
   valueAsString = normalizeEncodedBlock(
     yaml,
@@ -235,11 +237,10 @@ SourceEdit _removeFromBlockMap(
 
   endOffset = skipAndExtractCommentsInBlock(
     yaml,
-    endOffset,
-    null,
+    endOfNodeOffset: endOffset,
     lineEnding: lineEnding,
     greedy: true,
-  ).$1;
+  ).endOffset;
 
   final mapSize = map.length;
 

--- a/lib/src/map_mutations.dart
+++ b/lib/src/map_mutations.dart
@@ -183,7 +183,7 @@ SourceEdit _replaceInBlockMap(
 
   // Aggressively skip all comments
   final (offsetOfLastComment, _) =
-      skipAndExtractCommentsInBlock(yaml, end, null, lineEnding);
+      skipAndExtractCommentsInBlock(yaml, end, null, lineEnding: lineEnding);
   end = offsetOfLastComment;
 
   valueAsString = normalizeEncodedBlock(

--- a/lib/src/strings.dart
+++ b/lib/src/strings.dart
@@ -145,19 +145,25 @@ String? _tryYamlEncodeFolded(String string, int indentSize, String lineEnding) {
     stripped = stripped.substring(0, stripped.length - 1);
   }
 
-  /// If indeed we have a trailing line, we apply a `chomping hack`. We use a
-  /// `clip indicator` (no chomping indicator) if we need to ignore the `\n`
-  /// and `strip indicator` if not to remove any trailing indents.
+  /// If indeed we have a trailing line-break, we apply a `chomping hack`.
   ///
-  /// The caller of this method, that is, [yamlEncodeBlock] will apply a
-  /// dangling `\n` that will\should be normalized by
-  /// [normalizeEncodedBlock] which allows trailing `\n` for [folded]
-  /// strings such that:
-  ///  * If we had a string `"my string \n"`:
-  ///     1. This function excludes it and it becomes `>\n<indent>my string `
-  ///     2. [yamlEncodeBlock] applies `\n` that we skipped.
-  ///     2. [normalizeEncodedBlock] ignores the trailing `\n` for folded
-  ///        string by default.
+  /// We use a `clip indicator` (no chomping indicator) if we need to ignore the
+  /// `\n` and `strip indicator` to remove any trailing line-break and its
+  /// indent.
+  ///
+  /// The caller of this method, that is, [yamlEncodeBlock], will apply a
+  /// dangling `\n` that must be normalized by [normalizeEncodedBlock] which
+  /// allows trailing `\n` for [folded] strings such that:
+  ///  * If we had a string "example \n":
+  ///     1. This function excludes the line-break at the end and it becomes:
+  ///       - ">" + "\n" + <indent> + "example "
+  ///
+  ///     2. [yamlEncodeBlock] applies a dangling `\n` that we skipped and it
+  ///        becomes:
+  ///         - ">" + "\n" + <indent> + "example " + \n`
+  ///
+  ///     3. [normalizeEncodedBlock] never prunes the dangling `\n` applied for
+  ///        folded strings by default.
   return '>${ignoreTrailingLineBreak ? '' : '-'}\n'
       '$indent$trimmed'
       '${stripped.replaceAll(lineEnding, lineEnding + indent)}';
@@ -210,19 +216,25 @@ String? _tryYamlEncodeLiteral(
     stripped = stripped.substring(0, stripped.length - 1);
   }
 
-  /// If indeed we have a trailing line, we apply a `chomping hack`. We use a
-  /// `clip indicator` (no chomping indicator) if we need to ignore the `\n`
-  /// and `strip indicator` if not to remove any trailing indents.
+  /// If indeed we have a trailing line-break, we apply a `chomping hack`.
   ///
-  /// The caller of this method, that is, [yamlEncodeBlock] will apply a
-  /// dangling `\n` that will\should be normalized by
-  /// [normalizeEncodedBlock] which allows trailing `\n` for [literal]
-  /// strings such that:
-  ///  * If we had a string `"my string \n"`:
-  ///     1. This function excludes it and it becomes `|\n<indent>my string `
-  ///     2. [yamlEncodeBlock] applies `\n` that we skipped.
-  ///     2. [normalizeEncodedBlock] ignores the trailing `\n` for literal
-  ///        string by default.
+  /// We use a `clip indicator` (no chomping indicator) if we need to ignore the
+  /// `\n` and `strip indicator` to remove any trailing line-break and its
+  /// indent.
+  ///
+  /// The caller of this method, that is, [yamlEncodeBlock], will apply a
+  /// dangling `\n` that must be normalized by [normalizeEncodedBlock] which
+  /// allows trailing `\n` for [literal] strings such that:
+  ///  * If we had a string "example \n":
+  ///     1. This function excludes the line-break at the end and it becomes:
+  ///       - ">" + "\n" + <indent> + "example "
+  ///
+  ///     2. [yamlEncodeBlock] applies a dangling `\n` that we skipped and it
+  ///        becomes:
+  ///         - ">" + "\n" + <indent> + "example " + \n`
+  ///
+  ///     3. [normalizeEncodedBlock] never prunes the dangling `\n` applied for
+  ///        literal strings by default.
   return '|${ignoreTrailingLineBreak ? '' : '-'}\n'
       '$indent${trimmed.replaceAll('\n', lineEnding + indent)}'
       '${stripped.replaceAll(lineEnding, lineEnding + indent)}';

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -421,6 +421,30 @@ String getLineEnding(String yaml) {
   );
 }
 
+/// Reclaims any indent greedily skipped by [skipAndExtractCommentsInBlock]
+/// and returns the start `offset` (inclusive).
+///
+/// If [isSingle] is `true`, then the `offset` of the line-break is included.
+/// It is excluded if `false`.
+///
+/// It is recommended that this function is called when removing the last
+/// [YamlNode] in a block [YamlMap] or [YamlList].
+int reclaimIndentAndLinebreak(
+  String yaml,
+  int currentOffset, {
+  required bool isSingle,
+}) {
+  var indexOfLineBreak = yaml.lastIndexOf('\n', currentOffset);
+
+  /// In case, this isn't the only element, we ignore the line-break while
+  /// reclaiming the indent. As the element that remains, will have a line
+  /// break the next node needs to indicate start of a new node!
+  if (!isSingle) indexOfLineBreak += 1;
+
+  final indentDiff = currentOffset - indexOfLineBreak;
+  return currentOffset - indentDiff;
+}
+
 /// Normalizes an encoded [YamlNode] encoded as a string by pruning any
 /// dangling line-breaks.
 ///

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -402,7 +402,7 @@ String getLineEnding(String yaml) {
         currentOffset += comment.length;
         break;
       }
-      currentOffset = indexOfLineBreak + 1; // Skip line-break eagerly
+      currentOffset = indexOfLineBreak;
     }
 
     return (currentOffset, comments);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -297,9 +297,10 @@ String getLineEnding(String yaml) {
 (int endOffset, List<String> comments) skipAndExtractCommentsInBlock(
   String yaml,
   int currentEndOffset,
-  int? nextStartOffset, [
+  int? nextStartOffset, {
   String lineEnding = '\n',
-]) {
+  bool greedy = false,
+}) {
   /// If [nextStartOffset] is null, this may be the last element in a collection
   /// and thus we have to check and extract comments manually.
   ///
@@ -336,6 +337,13 @@ String getLineEnding(String yaml) {
       return (firstLineBreak, nextIndex);
     }
 
+    /// Returns the [currentOffset] if [greedy] is true. Otherwise, attempts
+    /// returning the [firstLineBreakOffset] if not null if [greedy] is false.
+    int earlyBreakOffset(int currentOffset, int? firstLineBreakOffset) {
+      if (greedy) return currentOffset;
+      return firstLineBreakOffset ?? currentOffset;
+    }
+
     var currentOffset = currentEndOffset;
 
     while (true) {
@@ -353,7 +361,7 @@ String getLineEnding(String yaml) {
         /// string. Since we lazily evaluated the string, attempt to return the
         /// first [lineEnding] we encountered only if not null.
         if (nextIndex == null) {
-          currentOffset = firstLE ?? yaml.length;
+          currentOffset = earlyBreakOffset(yaml.length, firstLE);
           break;
         }
 
@@ -373,7 +381,7 @@ String getLineEnding(String yaml) {
       /// Since we lazily evaluated the string, attempt to return the
       /// first [lineEnding] we encountered only if not null.
       if (indexOfCommentStart == -1) {
-        currentOffset = firstLineBreak ?? currentOffset;
+        currentOffset = earlyBreakOffset(currentOffset, firstLineBreak);
         break;
       }
 

--- a/test/string_test.dart
+++ b/test/string_test.dart
@@ -6,6 +6,7 @@ import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 import 'package:yaml_edit/yaml_edit.dart';
 
+// TODO: Add test for string with trailing space
 final _testStrings = [
   "this is a fairly' long string with\nline breaks",
   'whitespace\n after line breaks',


### PR DESCRIPTION
I debugged #89 further while submitting #91 and noted several issues that are closely coupled:

- Trailing line-break only applied to `YamlList` or `YamlMap` and never a `YamlScalar`
- Dangling comments and line-breaks left behind if a comment spans multiple lines.

This PR:
1. Applies a line break after each `YamlNode` encoded within a block.
2. Fixes #89.
3. Introduces a `normalizeEncodeBlock` function that dynamically prunes the additional line break if:
    - The deepest `YamlScalar` isn't encoded as `ScalarStyle.LITERAL` or `ScalarStyle.FOLDED`. Also fixes #89
    - The old node didn't have a trailing line-break.
4. Introduces a `skipAndExtractComments` function which greedily skips any comments and whitespace belonging to the `YamlNode` being replaced.

Further changes made in #93

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
