### PR TITLE
Refactor comment skipping

### DIFF
--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -245,8 +245,15 @@ class YamlEditor {
       final lineEnding = getLineEnding(_yaml);
       end = skipAndExtractCommentsInBlock(_yaml, end, null, lineEnding).$1;
       var encoded = yamlEncodeBlock(valueNode, 0, lineEnding);
-      encoded =
-          normalizeEncodedBlock(_yaml, lineEnding, end, valueNode, encoded);
+      encoded = normalizeEncodedBlock(
+        _yaml,
+        lineEnding: lineEnding,
+        nodeToReplaceEndOffset: end,
+        update: valueNode,
+        updateAsString: encoded,
+        skipPreservationCheck: true,
+        isTopLevelScalar: true,
+      );
       final edit = SourceEdit(start, end - start, encoded);
       return _performEdit(edit, path, valueNode);
     }

--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -252,7 +252,6 @@ class YamlEditor {
         update: valueNode,
         updateAsString: encoded,
         skipPreservationCheck: true,
-        isTopLevelScalar: true,
       );
       final edit = SourceEdit(start, end - start, encoded);
       return _performEdit(edit, path, valueNode);

--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -243,7 +243,13 @@ class YamlEditor {
       final start = _contents.span.start.offset;
       var end = getContentSensitiveEnd(_contents);
       final lineEnding = getLineEnding(_yaml);
-      end = skipAndExtractCommentsInBlock(_yaml, end, null, lineEnding).$1;
+      end = skipAndExtractCommentsInBlock(
+        _yaml,
+        end,
+        null,
+        lineEnding: lineEnding,
+        greedy: true,
+      ).$1;
       var encoded = yamlEncodeBlock(valueNode, 0, lineEnding);
       encoded = normalizeEncodedBlock(
         _yaml,

--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -243,9 +243,10 @@ class YamlEditor {
       final start = _contents.span.start.offset;
       final end = getContentSensitiveEnd(_contents);
       final lineEnding = getLineEnding(_yaml);
-      final edit = SourceEdit(
-          start, end - start, yamlEncodeBlock(valueNode, 0, lineEnding));
-
+      var encoded = yamlEncodeBlock(valueNode, 0, lineEnding);
+      encoded =
+          normalizeEncodedBlock(_yaml, lineEnding, end, valueNode, encoded);
+      final edit = SourceEdit(start, end - start, encoded);
       return _performEdit(edit, path, valueNode);
     }
 
@@ -483,7 +484,7 @@ class YamlEditor {
         if (!containsKey(map, keyOrIndex)) {
           return _pathErrorOrElse(path, path.take(i + 1), map, orElse);
         }
-        final keyNode = getKeyNode(map, keyOrIndex);
+        final (_, keyNode) = getKeyNode(map, keyOrIndex);
 
         if (checkAlias) {
           if (_aliases.contains(keyNode)) throw AliasException(path, keyNode);

--- a/lib/src/editor.dart
+++ b/lib/src/editor.dart
@@ -241,8 +241,9 @@ class YamlEditor {
 
     if (path.isEmpty) {
       final start = _contents.span.start.offset;
-      final end = getContentSensitiveEnd(_contents);
+      var end = getContentSensitiveEnd(_contents);
       final lineEnding = getLineEnding(_yaml);
+      end = skipAndExtractCommentsInBlock(_yaml, end, null, lineEnding).$1;
       var encoded = yamlEncodeBlock(valueNode, 0, lineEnding);
       encoded =
           normalizeEncodedBlock(_yaml, lineEnding, end, valueNode, encoded);

--- a/lib/src/equality.dart
+++ b/lib/src/equality.dart
@@ -87,8 +87,10 @@ int deepHashCode(Object? value) {
 }
 
 /// Returns the [YamlNode] corresponding to the provided [key].
-YamlNode getKeyNode(YamlMap map, Object? key) {
-  return map.nodes.keys.firstWhere((node) => deepEquals(node, key)) as YamlNode;
+(int index, YamlNode keyNode) getKeyNode(YamlMap map, Object? key) {
+  return map.nodes.keys.indexed.firstWhere(
+    (value) => deepEquals(value.$2, key),
+  ) as (int, YamlNode);
 }
 
 /// Returns the [YamlNode] after the [YamlNode] corresponding to the provided

--- a/lib/src/list_mutations.dart
+++ b/lib/src/list_mutations.dart
@@ -57,7 +57,7 @@ SourceEdit updateInList(
     final (offsetOfLastComment, _) =
         skipAndExtractCommentsInBlock(yaml, end, null, lineEnding);
     end = offsetOfLastComment;
-    
+
     valueString =
         normalizeEncodedBlock(yaml, lineEnding, end, newValue, valueString);
 

--- a/lib/src/list_mutations.dart
+++ b/lib/src/list_mutations.dart
@@ -58,13 +58,13 @@ SourceEdit updateInList(
         skipAndExtractCommentsInBlock(yaml, end, null, lineEnding);
     end = offsetOfLastComment;
 
-    valueString =
-        normalizeEncodedBlock(yaml, lineEnding, end, newValue, valueString);
-
-    /// [skipAndExtractCommentsInBlock] is greedy and eats up any whitespace
-    /// it encounters in search of comments. Compensate indent lost in the
-    /// current edit
-    if (index != list.length - 1) valueString += ' ' * listIndentation;
+    valueString = normalizeEncodedBlock(
+      yaml,
+      lineEnding: lineEnding,
+      nodeToReplaceEndOffset: end,
+      update: newValue,
+      updateAsString: valueString,
+    );
 
     return SourceEdit(offset, end - offset, valueString);
   } else {

--- a/lib/src/map_mutations.dart
+++ b/lib/src/map_mutations.dart
@@ -131,8 +131,7 @@ SourceEdit _replaceInBlockMap(
   final mapIndentation = getMapIndentation(yaml, map);
   final newIndentation = mapIndentation + getIndentation(yamlEdit);
 
-  // TODO: Compensate for the indent eaten up
-  final (keyIndex, keyNode) = getKeyNode(map, key);
+  final (_, keyNode) = getKeyNode(map, key);
 
   var valueAsString = yamlEncodeBlock(
     wrapAsYamlNode(newValue),
@@ -187,13 +186,13 @@ SourceEdit _replaceInBlockMap(
       skipAndExtractCommentsInBlock(yaml, end, null, lineEnding);
   end = offsetOfLastComment;
 
-  valueAsString =
-      normalizeEncodedBlock(yaml, lineEnding, end, newValue, valueAsString);
-
-  /// [skipAndExtractCommentsInBlock] is greedy and eats up any whitespace
-  /// it encounters in search of comments. Compensate indent lost in the
-  /// current edit
-  if (keyIndex != map.length - 1) valueAsString += ' ' * mapIndentation;
+  valueAsString = normalizeEncodedBlock(
+    yaml,
+    lineEnding: lineEnding,
+    nodeToReplaceEndOffset: end,
+    update: newValue,
+    updateAsString: valueAsString,
+  );
 
   return SourceEdit(start, end - start, valueAsString);
 }

--- a/lib/src/map_mutations.dart
+++ b/lib/src/map_mutations.dart
@@ -183,7 +183,7 @@ SourceEdit _replaceInBlockMap(
 
   // Aggressively skip all comments
   final (offsetOfLastComment, _) =
-      skipAndExtractCommentsInBlock(yaml, end, null, lineEnding);
+      skipAndExtractCommentsInBlock(yaml, end, null, lineEnding: lineEnding);
   end = offsetOfLastComment;
 
   valueAsString = normalizeEncodedBlock(

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -297,9 +297,10 @@ String getLineEnding(String yaml) {
 (int endOffset, List<String> comments) skipAndExtractCommentsInBlock(
   String yaml,
   int currentEndOffset,
-  int? nextStartOffset, [
+  int? nextStartOffset, {
   String lineEnding = '\n',
-]) {
+  bool greedy = false,
+}) {
   /// If [nextStartOffset] is null, this may be the last element in a collection
   /// and thus we have to check and extract comments manually.
   ///
@@ -336,6 +337,13 @@ String getLineEnding(String yaml) {
       return (firstLineBreak, nextIndex);
     }
 
+    /// Returns the [currentOffset] if [greedy] is true. Otherwise, attempts
+    /// returning the [firstLineBreakOffset] if not null if [greedy] is false.
+    int earlyBreakOffset(int currentOffset, int? firstLineBreakOffset) {
+      if (greedy) return currentOffset;
+      return firstLineBreakOffset ?? currentOffset;
+    }
+
     var currentOffset = currentEndOffset;
 
     while (true) {
@@ -353,7 +361,7 @@ String getLineEnding(String yaml) {
         /// string. Since we lazily evaluated the string, attempt to return the
         /// first [lineEnding] we encountered only if not null.
         if (nextIndex == null) {
-          currentOffset = firstLE ?? yaml.length;
+          currentOffset = earlyBreakOffset(yaml.length, firstLE);
           break;
         }
 
@@ -373,7 +381,7 @@ String getLineEnding(String yaml) {
       /// Since we lazily evaluated the string, attempt to return the
       /// first [lineEnding] we encountered only if not null.
       if (indexOfCommentStart == -1) {
-        currentOffset = firstLineBreak ?? currentOffset;
+        currentOffset = earlyBreakOffset(currentOffset, firstLineBreak);
         break;
       }
 


### PR DESCRIPTION
This PR improves #90 further by:

1. Lazily looking ahead for comments and aligns `skipAndExtractComments` with existing `YamlEditor` behaviour. The function now reverts back to the first line break it encountered when it looked ahead for comments by default
2. Allowing callers of `skipAndExtractComments` to explicitly specify whether it should greedily look ahead for comments.
3. Preventing the trailing line break for `YamlScalar`s with the `ScalarStyle`s plain, any, folded or literal from being pruned (may need additional tests to disprove `ScalarStyle.PLAIN` or `ScalarStye.ANY`)

Further changes made in #94

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
